### PR TITLE
respect timeouts+strict periods; add camera name to tweets

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Mars Rover Photos Twitter bot
 ```shell
 $ go get github.com/odeke-em/mars-rover-twitter-bot
 $ mars-rover-twitter-bot --help # For help
-$ mars-rover-twitter-bot --period-in-hours 24
+$ mars-rover-twitter-bot --offset-in-hours 72 # Start from 72 hours ago
 ```
 
 ## Environment variables


### PR DESCRIPTION
+ Add camera name to tweets to make it nicer. Also modified
the format for example now we have:
`Taken by camera FHAZ, on 2016-10-27 by Rover Curiosity launched on
2011-11-26. PhotoID: 594099`
https://twitter.com/odeke_et/status/792933207205216256

+ Respect timeouts strictly so that we stay on schedule and can
deliver tweets reliably even a tweet stalls.

+ Change period-in-hours to offset-in-hours because we want
times offset from now. Anyways, the Rover gives back photos
starting from an absolute day so offset makes more sense
and every 24 hours the process will be repeated and the
same offset applied still takes off 24 hours uniformly.